### PR TITLE
Remove Schibsted SMB link from footer (fixes #100)

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,9 +71,6 @@ Your photo does not have a GPS position? No problem, you can set it manually!  E
     <ul>
       <li><img src="assets/favicon-32x32.png" alt="Map on photo icon" /> Map on photo <span id="js-app-version"></span> - supported by:</li>
       <li>
-        <a href="https://schibstedforbusiness.com" title="Schibsted for business">Schibsted SMB</a>
-      </li>
-      <li>
         <a href="https://vitejs.dev" title="Vite Next Generation Frontend Tooling">Vite</a>
       </li>
       <li>


### PR DESCRIPTION
This PR removes the Schibsted SMB link from the footer as described in issue #100. No other content or functionality is affected.